### PR TITLE
Start skills-manager app

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,43 @@ Add this to the `.actrc` file if your action is more advance. Note: It is very b
 ```
 -P ubuntu-latest=catthehacker/ubuntu:full-latest
 ```
+
+# Manager React Application
+
+The `manager` folder contains a React application that displays a list of all repositories in the "skills" GitHub organization. The application uses the GitHub API to fetch repository data and displays the following information for each repository:
+
+- Repository ID
+- Repository name
+- URL
+- Star count
+- Last modified date
+- Topics
+
+The application is styled using the Primer design package.
+
+## How to Run the Application
+
+1. Navigate to the `manager` folder:
+   ```sh
+   cd manager
+   ```
+
+2. Install the dependencies:
+   ```sh
+   npm install
+   ```
+
+3. Start the development server:
+   ```sh
+   npm start
+   ```
+
+4. Open your browser and go to `http://localhost:3000` to see the application in action.
+
+## Additional Data
+
+The `manager` folder also contains a `mapping.json` file with additional data about each repository. The file includes the following information for each repository:
+
+- `ms_learn`
+- `learning_objective`
+- `github_features`

--- a/manager/README.md
+++ b/manager/README.md
@@ -1,0 +1,39 @@
+# Manager React Application
+
+The `manager` folder contains a React application that displays a list of all repositories in the "skills" GitHub organization. The application uses the GitHub API to fetch repository data and displays the following information for each repository:
+
+- Repository ID
+- Repository name
+- URL
+- Star count
+- Last modified date
+- Topics
+
+The application is styled using the Primer design package.
+
+## How to Run the Application
+
+1. Navigate to the `manager` folder:
+   ```sh
+   cd manager
+   ```
+
+2. Install the dependencies:
+   ```sh
+   npm install
+   ```
+
+3. Start the development server:
+   ```sh
+   npm start
+   ```
+
+4. Open your browser and go to `http://localhost:3000` to see the application in action.
+
+## Additional Data
+
+The `manager` folder also contains a `mapping.json` file with additional data about each repository. The file includes the following information for each repository:
+
+- `ms_learn`
+- `learning_objective`
+- `github_features`

--- a/manager/mapping.json
+++ b/manager/mapping.json
@@ -1,0 +1,14 @@
+{
+  "repos": [
+    {
+      "ms_learn": "ms_learn1",
+      "learning_objective": "learning_objective1",
+      "github_features": ["feature1", "feature2"]
+    },
+    {
+      "ms_learn": "ms_learn2",
+      "learning_objective": "learning_objective2",
+      "github_features": ["feature3", "feature4"]
+    }
+  ]
+}

--- a/manager/package.json
+++ b/manager/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "skills-manager",
+  "version": "1.0.0",
+  "description": "A React application to display a list of all repos in the 'skills' GitHub org",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "dependencies": {
+    "@primer/react": "^20.0.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "styled-components": "^5.3.3"
+  },
+  "devDependencies": {
+    "react-scripts": "4.0.3"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/manager/src/App.css
+++ b/manager/src/App.css
@@ -1,0 +1,37 @@
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: #f6f8fa;
+}
+
+h1 {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+h2 {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+p {
+  margin: 0.5rem 0;
+}
+
+.box {
+  padding: 1rem;
+  margin-bottom: 1rem;
+  border: 1px solid #e1e4e8;
+  border-radius: 0.5rem;
+  background-color: #fff;
+}
+
+.label {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  margin-right: 0.5rem;
+  background-color: #0366d6;
+  color: #fff;
+  border-radius: 0.25rem;
+}

--- a/manager/src/App.js
+++ b/manager/src/App.js
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Text, Link, Label } from '@primer/react';
+import './App.css';
+
+const App = () => {
+  const [repos, setRepos] = useState([]);
+
+  useEffect(() => {
+    const fetchRepos = async () => {
+      const response = await fetch('https://api.github.com/orgs/skills/repos');
+      const data = await response.json();
+      setRepos(data);
+    };
+
+    fetchRepos();
+  }, []);
+
+  return (
+    <Box p={3}>
+      <Text as="h1" fontSize={4} mb={3}>
+        Skills GitHub Repositories
+      </Text>
+      {repos.map((repo) => (
+        <Box key={repo.id} p={3} mb={3} borderWidth={1} borderStyle="solid" borderColor="border.default" borderRadius={2}>
+          <Text as="h2" fontSize={3} mb={2}>
+            <Link href={repo.html_url}>{repo.name}</Link>
+          </Text>
+          <Text as="p" mb={1}>
+            ID: {repo.id}
+          </Text>
+          <Text as="p" mb={1}>
+            Stars: {repo.stargazers_count}
+          </Text>
+          <Text as="p" mb={1}>
+            Last Modified: {new Date(repo.updated_at).toLocaleDateString()}
+          </Text>
+          <Box>
+            {repo.topics.map((topic) => (
+              <Label key={topic} mr={1}>
+                {topic}
+              </Label>
+            ))}
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
+export default App;

--- a/manager/src/index.js
+++ b/manager/src/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+import './App.css';
+
+ReactDOM.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+  document.getElementById('root')
+);


### PR DESCRIPTION
Creates a React application in the `manager` folder to display a list of all repos in the "skills" GitHub org.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/chriswblake/skills-manager/pull/1?shareId=c2d9948d-2711-411d-b19a-c273b84859d6).