### PR TITLE
feat: add check-broken-links workflow to scan all exercise repos

### DIFF
--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -53,9 +53,17 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          # TODO: Familiarize with lychee options to check for all relevant files and exclude unnecessary ones https://lychee.cli.rs/recipes/excluding-links/
-
-          args: --verbose --no-progress './**/*.md' './**/*.html' --include '^https://github.com/user-attachments/'
+          # Check all markdown and HTML files in the repository
+          # Exclude links that are private, file:// URLs, and links containing mustache-style variables ({{ }}) and their encoded form
+          args: |
+            --verbose
+            --no-progress
+            './**/*.md'
+            './**/*.html'
+            --exclude-all-private
+            --exclude 'file:///*'
+            --exclude '.*\{\{.*\}\}.*'
+            --exclude '.*%7B%7B.*%7D%7D.*'
           fail: false
 
       - name: Create Issue From File


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

We've had issues where our screenshots went missing, we are not 100% sure what was the reason. 

example fixed in [this commit](https://github.com/skills/introduction-to-repository-management/commit/4d62d5a1bf31b5d4233371494226e4a6dd44854c):
![image](https://github.com/user-attachments/assets/f49f5922-3b14-4409-ba24-a6d38872d6c4)

I suspect it may happen if an adds a link to an image on their fork or in `skills-dev` and then later on removes that repository.


Regardless the reason, this workflow will help us find and remediate broken links.



### Changes
<!-- Describe the changes this pull request introduces. -->

Add a workflow that will run https://github.com/lycheeverse/lychee-action on all user-attachment links in all repositories with `skills-course` label.

If there are any unreachable links, an issue will be created in `skills-manager`.


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes: https://github.com/github/public-content-credentaling/issues/298

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
