### PR TITLE
fix: update outdated prettier devcontainer feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
     },
 
     // Consistent formatting
-    "ghcr.io/devcontainers-contrib/features/prettier:1": {},
+    "ghcr.io/devcontainers-extra/features/prettier:1": {},
 
     // Python Support
     "ghcr.io/devcontainers/features/python:1": {


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

All of [`devcontainer-contrib`](https://github.com/danielbraun89/devcontainer-features/tree/main/src/prettier) features are archived and we should use [`devcontainers-extra`](https://github.com/devcontainers-extra/features/tree/main/src/prettier)

If you try to rebuild a codespace without this change it will fail on setting up `devcontainer-contrib` prettier feature - thanks @Chukslord1 for reporting this!


### Changes
<!-- Describe the changes this pull request introduces. -->
This pull request includes a small update to the `.devcontainer/devcontainer.json` file. The change updates the Prettier feature reference to use `ghcr.io/devcontainers-extra` instead of `ghcr.io/devcontainers-contrib`.

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L18-R18): Updated the Prettier feature reference to `ghcr.io/devcontainers-extra/features/prettier:1` for consistency or improved compatibility.

<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
