### PR TITLE
chore: use remote GitHub MCP server

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,26 +1,8 @@
 {
   "servers": {
     "github": {
-      "command": "docker",
-      "args": [
-        "run",
-        "-i",
-        "--rm",
-        "-e",
-        "GITHUB_PERSONAL_ACCESS_TOKEN",
-        "ghcr.io/github/github-mcp-server:v0.4.0"
-      ],
-      "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "${input:github_token}"
-      }
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
     }
-  },
-  "inputs": [
-    {
-      "type": "promptString",
-      "id": "github_token",
-      "description": "GitHub Personal Access Token",
-      "password": true
-    }
-  ]
+  }
 }


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

This pull request updates the `.vscode/mcp.json` file to simplify the configuration for connecting to the GitHub MCP server. The most significant change is switching from a Docker-based setup to an HTTP-based configuration.

Configuration simplification:

* [`.vscode/mcp.json`](diffhunk://#diff-756c99ad6a15758981c15d6ba32a2d83391908e8e021f0399e9d34339dc4eadaL4-L25): Replaced the Docker-based server setup with an HTTP-based configuration using a direct URL (`https://api.githubcopilot.com/mcp/`) and removed the need for a personal access token prompt.

### Changes
<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
