### PR TITLE
docs: clarify when and how to post feedback during workflow runs

### DIFF
--- a/docs/2-design/design.md
+++ b/docs/2-design/design.md
@@ -91,13 +91,16 @@ When the user triggers the action, it will check for expected outputs and add an
      - Boilerplate steps are outside this.
      - Do not combine checks. Keep each independent.
      - All checks should use `continue-on-error: true`
-   - All checks are combined to provide feedback by creating/updating an issue comment, typically as a table.
-     - If the check fails, the comment provides useful feedback for trying again.
-     - If the check passes, the comment to provides feedback that they did a good job.
+   - All checks are combined to provide feedback by updating the last issue comment, typically as a table. This job does not create any net new comments.
+     - If the check fails, the comment provides useful feedback for trying again and fails the job
+     - If the check passes, the comment to provides feedback that they completed what was asked and passes the job so the workflow continues to the next job - `post_next_step_content`.
 
 1. `post_next_step_content` - Loads the next step content and creates an issue comment.
+   - Comments that the previous step is finished (unless it was the first step)
    - Disables the current step workflow, so it will never run again.
    - Enables the next step workflow.
+   - Comments with the next step content
+   - Comments that Mona is watching for progress (unless it was the last step)
 
 > [!CAUTION]
 > Do **NOT** create a workflow that triggers on `main` without a `paths` filter.


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

This comes after changes in the exercise-template PR https://github.com/skills/exercise-template/pull/80 and [implemented in github-pages exercise](https://github.com/skills/github-pages/pull/1090)

This guarantees that the user is congratulated for completing a step regardless of the workflow having a `check_step_work` job, because that commenting is moved to `post_next_step_content`

### Changes
<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
