### PR TITLE
Revert "chore: move mcp server configuration to devcontainer"

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -100,14 +100,6 @@
         // Javascript
         "jest.enable": false
       }
-    },
-    "mcp": {
-      "servers": {
-        "github": {
-          "type": "http",
-          "url": "https://api.githubcopilot.com/mcp/"
-        }
-      }
     }
   },
 

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,8 @@
+{
+  "servers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
+    }
+  }
+}


### PR DESCRIPTION
Reverts skills/skills-manager#21

Not sure if something happened in vscode, but this stopped working for me. "list servers" isn't showing up the `github` server even after rebuilding the devcontainer

@arilivigni @chriswblake did you encounter any issues?