### PR TITLE
feat: add bootstrap exercise from outline prompt file

### DIFF
--- a/.github/instructions/step-workflows.instructions.md
+++ b/.github/instructions/step-workflows.instructions.md
@@ -17,6 +17,10 @@ GitHub Skills exercises use a **step-based workflow pattern** where each step (1
 
 ### Workflow Structure Details
 
+**Workflow Naming Convention**: Each workflow should use a simple naming convention, without additional descriptive text:
+- `name: Step 0` for the start exercise workflow
+- `name: Step 1`, `name: Step 2`, etc. for learning step workflows
+
 Each learning step has it's own workflow and is required to have the following two or three (if using grading) jobs:
 
 1. `find_exercise` - Calls a reusable workflow that finds the appropriate issue and returns the issue url for use in the next jobs.
@@ -27,6 +31,7 @@ Each learning step has it's own workflow and is required to have the following t
    - Enables the next step workflow.
    - Comments with the next step content
    - Comments that Mona is watching for progress (unless it was the last step)
+
 
 #### Example of a step workflow without grading
 

--- a/.github/prompts/bootstrap-exercise-from-outline.prompt.md
+++ b/.github/prompts/bootstrap-exercise-from-outline.prompt.md
@@ -1,0 +1,88 @@
+---
+mode: "agent"
+model: Claude Sonnet 4
+description: "Bootstrap a new exercise from outline"
+---
+
+# Bootstrap Exercise from Outline
+
+When you have an exercise outline, follow these steps to bootstrap a repository freshly created from the exercise-template repository:
+
+## 1. Readme Setup
+
+1. **Update README.md** - Replace template content with exercise-specific information from the outline:
+
+   - Title from outline
+   - Brief introduction (max 2 sentences)
+   - Overview section with learning objectives
+   - "What you will build" description
+   - Prerequisites list
+   - Remove template placeholder text
+  
+  Keep the original format of the README!
+
+## 2. Step Content files Setup
+
+1. **Create step content files** - Generate `.github/steps/N-step.md` files for each step in the outline if not already present:
+
+   - Create one file per step (1-step.md, 2-step.md, etc.)
+   - Add story sections if provided in outline
+   - Convert theory content into digestible sections. Include links to references to read more about the topic.
+   - Transform activity descriptions into numbered, actionable instructions
+   - Follow [`.github/instructions/step-content.instructions.md`](../instructions/step-content.instructions.md) for formatting
+
+1. **Create review content file** - Generate `.github/steps/x-review.md`:
+   - Summarize skills learned
+   - Include "What's next?" links
+   - Follow outline review section
+
+## 3. Step Workflow files Setup
+
+1. **Update start exercise workflow** - Modify `.github/workflows/0-start-exercise.yml`:
+
+   - Update exercise title and intro message placeholders
+   - Add any "On Start" automation from outline if present
+   - Ensure proper issue creation and workflow state management
+
+1. **Create step workflows** - Generate `.github/workflows/N-step.yml` files:
+
+   - One workflow per step
+   - Configure event triggers based on outline transition specifications
+   - Add grading checks if specified in outline.
+   - Update workflow names and step file references
+
+1. **Configure workflow triggers** - Set appropriate `on:` events:
+
+   - Match outline "Actions Trigger" specifications
+   - Add proper `paths:` filters for push events
+   - Configure specific event types (e.g., `pull_request: types: [closed]`)
+
+1. **Configure grading checks** - Implement workflow validation:
+
+   - Add `check_step_work` jobs for steps requiring grading
+   - Use appropriate actions (file-exists, keyphrase-checker, etc.)
+   - Match outline "Grading-Check" specifications
+   - Follow grading job pattern from [`.github/instructions/step-workflows.instructions.md`](../instructions/step-workflows.instructions.md)
+
+1. **Update environment variables** - Set proper step file paths:
+
+   - Update `STEP_N_FILE` variables in workflows
+   - Ensure workflow names match in enable/disable commands
+
+## 4. Final validation
+
+1. **Validate structure** - Ensure consistency:
+
+   - All workflows reference correct step files
+   - Workflow names match step numbers
+   - Event triggers align with learning objectives
+   - Grading checks match step requirements
+   - Last step workflow calls `finish-exercise.yml` instead of enabling next step
+   - Intermediate steps do not call `finish-exercise.yml`
+
+1. **Review content flow** - Verify logical progression:
+
+   - Each step builds on previous knowledge
+   - Activities match theory sections
+   - Transitions make sense for workflow triggers
+


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

You would use this prompt to bootstrap a brand new exercise.
All you need is a fresh repository created from [exercise-template](https://github.com/skills/exercise-template) and an outline that can be created with[ create-exercise-outline](https://github.com/skills/skills-manager/blob/main/.github/prompts/create-exercise-outline.prompt.md) prompt

After the initial bootstrapping you would edit what's needed. You can continue to prompt copilot chat for that and instruction files will be automatically applied for step markdown files and workflows

### Changes
<!-- Describe the changes this pull request introduces. -->


* **Bootstrap Exercise Prompt file**: Created a comprehensive prompt for setting up a new exercise from an outline, covering README updates, step content files, step workflows, grading checks, and final validation. (`.github/prompts/bootstrap-exercise-from-outline.prompt.md`).

<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
