### PR TITLE
fix: Exclude GitHub organization links from checks

### DIFF
--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -64,6 +64,8 @@ jobs:
             --exclude 'file:///*'
             --exclude '.*\{\{.*\}\}.*'
             --exclude '.*%7B%7B.*%7D%7D.*'
+            --exclude https://github.com/organizations/
+            --accept 200,429
           fail: false
 
       - name: Create Issue From File


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

Not the prettiest fix for the organizations. However unsure how to go around it for now.

The migrate-ado-repository [contains](https://github.com/skills/migrate-ado-repository/blob/61166b98d9b03109c1bfe5087da230f9c3e074f5/.github/steps/4-step.md?plain=1#L30) a nunjucks templated link in this format `https://github.com/organizations/{{ github_org }}/settings/installations` and the previously used exclude flag (`--exclude '.*\{\{.*\}\}.*'`) does not cover it and treats the first part (https://github.com/organizations/) as a link - which in itself returns 404. 

I've spent about an hour trying to adjust the regex or search lychee docs for an alternative solution but couldn't make it work

### Changes
<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes: https://github.com/skills/exercise-manager/issues/49

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
