### PR TITLE
feat: add publish prompt

### DIFF
--- a/.github/prompts/publish-exercise.prompt.md
+++ b/.github/prompts/publish-exercise.prompt.md
@@ -1,0 +1,73 @@
+---
+agent: agent
+description: Publishes a GitHub Skills exercise repository to the current user's GitHub Account.
+---
+
+# Publish Exercise
+
+1. Check the current repository for a remote. If it already has one, do nothing.
+   
+   - Only consider repositories in the `/workspaces/repos/**` folder.
+
+2. Try to determine the current user's GitHub account username.
+   
+   - GitHub CLI authenticated user
+   - Environment variables
+   - Other repositories in the parent folder.
+
+3. Ask the user if they would like to publish the current exercise repository to that location.
+  
+  - If they reject, do nothing and exit.
+
+  - If they confirm, create an empty repository in their account with the same name as the current exercise repository. Add the remote but do not publish the exercise repository yet!
+
+    ```bash
+    gh repo create {owner}/{exercise-name} --private --add-readme=false
+    ```
+
+4. Disable Actions on the repository to prevent any of the exercise workflows from accidentally triggering during publishing.
+
+  ```bash
+  gh api -X PUT repos/{owner}/{exercise-name}/actions/permissions -F enabled=false | cat
+  ```
+
+4. Before publishing, adjust the following repository settings:
+
+  1. Set the repository as template.
+
+   ```bash
+   gh api -X PATCH /repos/{owner}/{exercise-name} -f is_template=true | cat
+   ```
+
+  2. Set the repository description to match the exercise description from the top of the README.
+
+   ```bash
+   gh api -X PATCH /repos/{owner}/{exercise-name} -f description="{description}" | cat
+   ```
+
+5. Publish the exercise repository to the user's account.
+
+   - If you fail to publish it, there is probably a permissions issue. Ask the user to manually publish.
+
+    ```bash
+    git push -u origin main
+    ```
+    - Do not continue until the repository is successfully published, otherwise the next steps do not make sense.
+
+6. After publishing, disable current workflows and reenable Actions.
+
+  1. Check the exercise repository for workflows. Disable all workflows that are found.
+  
+   ```bash
+    gh api -X GET /repos/{owner}/{exercise-name}/actions/workflows | cat
+   ```
+   
+   ```bash
+    gh api -X PUT /repos/{owner}/{exercise-name}/actions/workflows/{workflow_id}/disable | cat
+   ```
+
+  2. Re-enable Actions on the repository, leaving workflows disabled and untriggered.
+
+     ```bash
+    gh api -X PUT repos/{owner}/{exercise-name}/actions/permissions -F enabled=true | cat
+    ```

--- a/.github/prompts/publish-exercise.prompt.md
+++ b/.github/prompts/publish-exercise.prompt.md
@@ -22,7 +22,7 @@ description: Publishes a GitHub Skills exercise repository to the current user's
   - If they confirm, create an empty repository in their account with the same name as the current exercise repository. Add the remote but do not publish the exercise repository yet!
 
     ```bash
-    gh repo create {owner}/{exercise-name} --private --add-readme=false
+    gh repo create {owner}/{exercise-name} --private
     ```
 
 4. Disable Actions on the repository to prevent any of the exercise workflows from accidentally triggering during publishing.

--- a/.github/prompts/publish-exercise.prompt.md
+++ b/.github/prompts/publish-exercise.prompt.md
@@ -36,7 +36,7 @@ description: Publishes a GitHub Skills exercise repository to the current user's
   1. Set the repository as template.
 
    ```bash
-   gh api -X PATCH /repos/{owner}/{exercise-name} -f is_template=true | cat
+   gh api -X PATCH /repos/{owner}/{exercise-name} -F is_template=true | cat
    ```
 
   2. Set the repository description to match the exercise description from the top of the README.

--- a/.github/prompts/publish-exercise.prompt.md
+++ b/.github/prompts/publish-exercise.prompt.md
@@ -31,7 +31,7 @@ description: Publishes a GitHub Skills exercise repository to the current user's
   gh api -X PUT repos/{owner}/{exercise-name}/actions/permissions -F enabled=false | cat
   ```
 
-4. Before publishing, adjust the following repository settings:
+5. Before publishing, adjust the following repository settings:
 
   1. Set the repository as template.
 
@@ -45,7 +45,7 @@ description: Publishes a GitHub Skills exercise repository to the current user's
    gh api -X PATCH /repos/{owner}/{exercise-name} -f description="{description}" | cat
    ```
 
-5. Publish the exercise repository to the user's account.
+6. Publish the exercise repository to the user's account.
 
    - If you fail to publish it, there is probably a permissions issue. Ask the user to manually publish.
 
@@ -54,7 +54,7 @@ description: Publishes a GitHub Skills exercise repository to the current user's
     ```
     - Do not continue until the repository is successfully published, otherwise the next steps do not make sense.
 
-6. After publishing, disable current workflows and reenable Actions.
+7. After publishing, disable current workflows and reenable Actions.
 
   1. Check the exercise repository for workflows. Disable all workflows that are found.
   

--- a/.github/prompts/publish-exercise.prompt.md
+++ b/.github/prompts/publish-exercise.prompt.md
@@ -68,6 +68,6 @@ description: Publishes a GitHub Skills exercise repository to the current user's
 
   2. Re-enable Actions on the repository, leaving workflows disabled and untriggered.
 
-     ```bash
-    gh api -X PUT repos/{owner}/{exercise-name}/actions/permissions -F enabled=true | cat
-    ```
+   ```bash
+   gh api -X PUT repos/{owner}/{exercise-name}/actions/permissions -F enabled=true | cat
+   ```

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ With the help of GitHub Copilot, making a new exercise from scratch can be very 
 
    > 💡 **Tip:** We are working on prompts to help refine the initial draft exercise. If you have ideas, please [open a new feature issue](https://github.com/skills/exercise-creator/issues/new?template=BLANK_ISSUE&title=replace-me:%20prompt%20name&body=replace-me:%20I%20have%20an%20idea%20for%20a%20prompt%20to%20help%20refine%20exercises)! 🧑‍🚀
 
+1. Ask Copilot to review the exercise for common issues.
+
+   ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
+
+   ```prompt
+   /review-exercise
+   ```
+
 1. Use the following Copilot prompt to publish the exercise to your account.
 
    ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This is a codespace with guidelines for developing and managing GitHub Skills ex
 ## Start the Codespace
 
 1. (Optional) For additional permissions options, fork the repository to your account/organization.
-
    - By default a Codespace only has access to the original repository and your user space.
    - If you need to [edit exercises across multiple accounts/organizations](docs/guide/configuration/work-across-multiple-organizations.md), you will need to change a few settings.
 
@@ -61,7 +60,7 @@ With the help of GitHub Copilot, making a new exercise from scratch can be very 
 1. Use the following Copilot prompt to create an actual exercise.
 
    ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
-   
+
    ```prompt
    /bootstrap-exercise-from-outline
    ```
@@ -70,17 +69,17 @@ With the help of GitHub Copilot, making a new exercise from scratch can be very 
 
    > 💡 **Tip:** We are working on prompts to help refine the initial draft exercise. If you have ideas, please [open a new feature issue](https://github.com/skills/exercise-creator/issues/new?template=BLANK_ISSUE&title=replace-me:%20prompt%20name&body=replace-me:%20I%20have%20an%20idea%20for%20a%20prompt%20to%20help%20refine%20exercises)! 🧑‍🚀
 
-1. Ask Copilot to review the exercise for common issues.
+1. Use the following Copilot prompt to publish the exercise to your account.
 
    ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
-   
+
    ```prompt
-   /review-exercise
+   /publish-exercise
    ```
 
-1. Test it with your friends and coworkers to make it awesome! 😎
+1. Go to the exercise repo and give it a test run! 😎
 
-1. Publish it and enjoy! 🚀
+1. Share it with your friends and coworkers! 🥳 🚀
 
 ## Work on an Existing Exercise
 


### PR DESCRIPTION
This pull request introduces a new Copilot prompt for publishing GitHub Skills exercises to a user's account and updates the documentation to guide users through this process. The main changes focus on adding the `/publish-exercise` prompt and revising the workflow for creating and sharing exercises.

Documentation updates for publishing exercises:

* Added `.github/prompts/publish-exercise.prompt.md` with detailed instructions for publishing an exercise repository, including steps for creating the repo, disabling/enabling Actions, and updating settings.
* Updated `README.md` to replace the review workflow with the new `/publish-exercise` prompt, and revised instructions for testing and sharing exercises.