### PR TITLE
chore: remove prompt files as agent skills are a superset of features

### DIFF
--- a/.github/prompts/bootstrap-exercise-from-outline.prompt.md
+++ b/.github/prompts/bootstrap-exercise-from-outline.prompt.md
@@ -1,8 +1,0 @@
----
-name: "bootstrap-exercise-from-outline"
-agent: "agent"
-description: "Bootstrap a new exercise from outline"
----
-
-Use the repository Agent Skill at `.github/skills/bootstrap-exercise-from-outline/SKILL.md`.
-If that file is missing, report the missing path and stop.

--- a/.github/prompts/create-exercise-outline.prompt.md
+++ b/.github/prompts/create-exercise-outline.prompt.md
@@ -1,8 +1,0 @@
----
-name: 'create-exercise-outline'
-agent: 'agent'
-description: 'Create a new exercise outline for a GitHub Skills exercise.'
----
-
-Use the repository Agent Skill at `.github/skills/create-exercise-outline/SKILL.md`.
-If that file is missing, report the missing path and stop.

--- a/.github/prompts/publish-exercise.prompt.md
+++ b/.github/prompts/publish-exercise.prompt.md
@@ -1,8 +1,0 @@
----
-name: "publish-exercise"
-agent: agent
-description: Publishes a GitHub Skills exercise repository to the current user's GitHub Account.
----
-
-Use the repository Agent Skill at `.github/skills/publish-exercise/SKILL.md`.
-If that file is missing, report the missing path and stop.

--- a/.github/prompts/review-exercise.prompt.md
+++ b/.github/prompts/review-exercise.prompt.md
@@ -1,8 +1,0 @@
----
-name: "review-exercise"
-agent: "agent"
-description: "Review the format and quality of a GitHub Skills exercise."
----
-
-Use the repository Agent Skill at `.github/skills/review-exercise/SKILL.md`.
-If that file is missing, report the missing path and stop.


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

https://code.visualstudio.com/docs/copilot/customization/agent-skills#_use-skills-as-slash-commands

Agent Skills can also be used as slash commands, therefore there is no use in having prompt files kept in the repo anymore

### Changes
<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
